### PR TITLE
Gulp Tasks exits

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -11,7 +11,8 @@ type DoneCallback = (error?: any) => void;
 
 @autobind
 export class Registry<TConfig extends ContextConfig = ContextConfig> extends DefaultRegistry {
-  protected readonly context: TaskContext<TConfig>;
+  private _context: TaskContext<TConfig>;
+  private _config: TConfig;
   private gulp: Gulp;
 
   constructor(
@@ -19,13 +20,18 @@ export class Registry<TConfig extends ContextConfig = ContextConfig> extends Def
   ) {
     super();
     assert(typeof config.rootPath === 'string', 'rootPath must be defined in Registry options');
-    this.context = new TaskContext<TConfig>(config);
+    this._config = config;
+  }
+
+  public get context(): TaskContext<TConfig> {
+    return this._context;
   }
 
   public init(gulp: Gulp) {
     super.init(gulp);
     // hackish
     this.gulp = gulp;
+    this._context = new TaskContext<TConfig>(this._config, gulp);
     /* tslint:disable-next-line */
     const tracker = new TaskTracker(gulp);
   }

--- a/src/taskContext.ts
+++ b/src/taskContext.ts
@@ -1,3 +1,4 @@
+import {Gulp} from 'gulp';
 import {autobind} from 'core-decorators';
 import {ChildProcess} from 'child_process';
 import * as killTree from 'tree-kill';
@@ -19,7 +20,7 @@ export class TaskContext<TConfig extends ContextConfig = ContextConfig> {
   public readonly config: TConfig;
   public registerCommand = this.commands.register;
 
-  constructor(config: TConfig) {
+  constructor(config: TConfig, gulp: Gulp) {
     this.config = mergeDefaultConfig<TConfig>(config);
 
     this.commands.register('q', {
@@ -30,7 +31,8 @@ export class TaskContext<TConfig extends ContextConfig = ContextConfig> {
       handler: this.commands.list,
       description: 'List available commands'
     });
-    this.commands.listen();
+
+    gulp.on('start', () => this.commands.listen());
 
     process.on('exit', this.exitGracefully);
   }


### PR DESCRIPTION
only listen for commands after gulp start event, this allows gulp --tasks to exit